### PR TITLE
Crash fix and small search improvement

### DIFF
--- a/social/src/main/java/com/amity/socialcloud/uikit/community/home/fragments/AmityCommunityHomeViewModel.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/home/fragments/AmityCommunityHomeViewModel.kt
@@ -2,10 +2,10 @@ package com.amity.socialcloud.uikit.community.home.fragments
 
 import androidx.databinding.ObservableBoolean
 import com.amity.socialcloud.uikit.common.base.AmityBaseViewModel
-import io.reactivex.rxjava3.subjects.PublishSubject
+import io.reactivex.rxjava3.subjects.BehaviorSubject
 
 class AmityCommunityHomeViewModel : AmityBaseViewModel() {
     var isSearchMode = ObservableBoolean(false)
     val emptySearchString = ObservableBoolean(true)
-    val textChangeSubject: PublishSubject<String> = PublishSubject.create()
+    val textChangeSubject: BehaviorSubject<String> = BehaviorSubject.create()
 }


### PR DESCRIPTION
- Fixed crash when `lateinit` property was not initialized when `Fragment` was recreated by system, not via `Builder`
- Fixed bug when search query was cleared after `Fragment` recreation 